### PR TITLE
Use new screensaver name for required components

### DIFF
--- a/session/i3-cinnamon.session
+++ b/session/i3-cinnamon.session
@@ -2,5 +2,5 @@
 
 [Cinnamon Session]
 Name=i3-cinnamon
-RequiredComponents=i3-cinnamon;cinnamon-screensaver;nm-applet;cinnamon-killer-daemon;polkit-gnome-authentication-agent-1;
+RequiredComponents=i3-cinnamon;org.cinnamon.ScreenSaver;nm-applet;cinnamon-killer-daemon;polkit-gnome-authentication-agent-1;
 DesktopName=X-Cinnamon


### PR DESCRIPTION
i3-cinnamon will fail to start after users update to the latest cinnamon.

Upstream https://github.com/linuxmint/Cinnamon they changed the name of the screensaver in required components to org.cinnamon.ScreenSaver